### PR TITLE
REW-2794-Product-Variant-Verbiage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Adding an end-point
 - create a file in `/includes/api/{module}`
-- use the structure, language and style from `/includes/example/_kittens.md` 
+- use the structure, language and style from `/includes/example/_kittens.md`
 - add the file to `includes:` section of `index.html.md` (alphabetically)
 
 Once the changes have been made, create a PR to master. When the PR is merged, GitHub Actions will pickup the changes and deploy.
@@ -24,13 +24,13 @@ Each section should contain the following elements in this order:
 
 - `> Header:`
 - `> Body:` (POST only)
-- `> Response:` 
+- `> Response:`
 - Description of the end point
 - H4 (####) HTTP Request
 - GET/POST/DELETE
-- H4 (####) Request Parameters 
+- H4 (####) Request Parameters
   - _if there are URL and Body params, then create two more sections:_
-  - H5 (#####) URL Parameters 
+  - H5 (#####) URL Parameters
   - H5 (#####) Body Parameters
 - H4 (####) Response Parameters
  

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Each section should contain the following elements in this order:
   - H5 (#####) URL Parameters
   - H5 (#####) Body Parameters
 - H4 (####) Response Parameters
- 
 
+## Testing Locally
 
+### Requirements
+- Git
+- Docker with compose
+
+### Steps
+1. Clone the repo.
+2. Run `docker compose build` at least once to build the images.
+3. Run `docker compose up` to start the slate instance container.
+4. Visit `http://localhost/` in your browser.
+5. Make changes to the markdown files in the `source` folder.
+6. Refresh the browser to see the changes.
+7. When done, run `docker compose down` to stop the container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,16 @@
----
-version: '3'
 services:
+
   slate:
     build:
-      context: .
+      context: ./
     volumes:
-      - .:/srv/slate
+      - ./:/srv/slate/
     ports:
-      - 4567:4567
-    command: sh -c '
-      bundle install &&
-      if [ "$BYEBUG" -eq "1" ];
-        then echo "sleeping";
-        sleep 100d;
-      else
-        bundle exec middleman server;
-      fi
-      '
+      - 80:4567
+    entrypoint: >-
+      /usr/bin/env bash -e -c
+    command:
+      - >-
+        bundle install &&
+        /srv/slate/slate.sh build &&
+        /srv/slate/slate.sh serve;

--- a/source/includes/api/products/create_product_v2.md
+++ b/source/includes/api/products/create_product_v2.md
@@ -220,7 +220,8 @@ voucher  | Boolean  |  Required - indicates if this product is to be treated as 
 lowest_denomination  | Integer  | Optional conditional - if this product is considered a voucher this field should indicate the lowest denomination of voucher available
 catalogue_id  | Integer  |  Optional - The id of the catalogue the product should belong to
 categories  | Array  |  Optional - An array of category ids that the product should belong to
-variants  | Array  |  Required - this is (somewhat convolutedly) a list of at 0 or more JSON encoded strings representing objects for a variant
+brand_id  | Integer  | Optional - this indicates a brand. Note this is not the name of the brand, but the id of the brand as stored in GPS
+variants  | Array[Strings]  |  Optional - an array of JSON encoded strings representing objects, one for each variant that belongs to this master product
 variants.available  | Boolean  |  Required - indicates the availability of this particular variant
 variants.product_sku  | String  |  Required - this is a 'key' that links this variant to its parent product, the value should be the SKU of the main product we are posting
 variants.sku  | String  |  Required - this is the SKU of this particular variant and should be unique
@@ -228,4 +229,3 @@ variants.face_value  | Integer  |  Required conditional - if this product is a v
 variants.base_price  | Float  |  Required conditional - for non-voucher products all variants will have the same cost/base price but voucher denominations will have differing base prices
 variants.voucher_status  | Boolean  |  Required - indicated this variant is a voucher - you cannot mix vouchers and physical product variants this should be all or nothing and match the parent product
 variants.variant  | String  |  Required - for non voucher products this represents the reason for the variation such as size (medium large etc) or colour. For vouchers this represents the face value of this denomination
-brand_id  | Integer  | Optional - this indicates a brand. Note this is not the name of the brand, but the id of the brand as stored in GPS

--- a/source/includes/api/products/create_product_v3.md
+++ b/source/includes/api/products/create_product_v3.md
@@ -360,7 +360,7 @@ brand_id | Integer | Optional - this indicates a brand. Note this is not the nam
 catalogue_id | Integer | Optional - the ID of the catalogue the product should belong to
 categories | Array of Integers | Optional - an array of category IDs that the product should belong to
 variant_type_id | Integer | Optional - the ID of a variant type in GPS (Colour = 1, Size = 2, Other = 8). Ignored for vouchers (since their variants are always denominations)
-variants | Array | Optional - an array of variants or denominations for this product
+variants | Array[Objects] | Optional - an array of variants or denominations that belong to this master product
 variants.variant | String | Required - for non-voucher products this represents the reason for the variation such as size (medium large etc) or colour. For vouchers this represents the face value of this denomination
 variants.sku | String | Required - this is the SKU of this particular variant and should be unique
 variants.face_value | Integer | Required (conditional) - if this product is a voucher, this shows the face value of this denomination

--- a/source/includes/api/products/update_product.md
+++ b/source/includes/api/products/update_product.md
@@ -2,6 +2,15 @@
 
 The update product API is available to update product information.
 
+<aside class="warning">
+    <b><u>IMPORTANT</u></b><br />
+    <div style="margin-left:25px;">
+        When updating an existing product that has variants, it is important that <b><u>all</u></b> variants be included in the update request.<br />
+        Products can only be updated using the V2 API; each variant should be provided as a JSON encoded string within the variants array.<br />
+        Any variants that are not included in the update request will be removed from the product.
+    </div>
+</aside>
+
 > Request
 
 ``` http

--- a/source/includes/api/products/update_product.md
+++ b/source/includes/api/products/update_product.md
@@ -178,7 +178,8 @@ delivery_type_id  | Integer  |  Optional - delivery types in GPS are (but not li
 voucher  | Boolean  |  Optional - indicates if this product is to be treated as a voucher
 lowest_denomination  | Integer  | Optional conditional - if this product is considered a voucher this field should indicate the lowest denomination of voucher available
 catalogue_id  | Integer  |  Optional - The id of the catalogue the product should belong to
-variants  | Array  |  Optional - this is (somewhat convolutedly) a list of at 0 or more JSON encoded strings representing objects for a variant
+brand_id  | Integer  | Optional - this indicates a brand. Note this is not the name of the brand, but the id of the brand as stored in GPS
+variants  | Array[Strings]  |  Optional - an array of JSON encoded strings representing objects, one for each variant that belongs to this master product
 variants.available  | Boolean  |  Required for each variant added - indicates the availability of this particular variant
 variants.product_sku  | String  |  Required for each variant added - this is a 'key' that links this variant to its parent product, the value should be the SKU of the main product we are posting
 variants.sku  | String  |  Required for each variant added - this is the SKU of this particular variant and should be unique
@@ -186,4 +187,3 @@ variants.face_value  | Integer  |  Required for each variant added - conditional
 variants.base_price  | Float  |  Required for each variant added - conditional - for non-voucher products all variants will have the same cost/base price but voucher denominations will have differing base prices
 variants.voucher_status  | Boolean  |  Required for each variant added - indicated this variant is a voucher - you cannot mix vouchers and physical product variants this should be all or nothing and match the parent product
 variants.variant  | String  |  Required for each variant added - for non voucher products this represents the reason for the variation such as size (medium large etc) or colour. For vouchers this represents the face value of this denomination
-brand_id  | Integer  | Optional - this indicates a brand. Note this is not the name of the brand, but the id of the brand as stored in GPS

--- a/source/includes/api/products/update_product.md
+++ b/source/includes/api/products/update_product.md
@@ -13,7 +13,7 @@ The update product API is available to update product information.
 
 > Request
 
-``` http
+```http
 PATCH /api/v2/products/{product_id} HTTP/1.1
 Authorization: Token token=xxx
 Content-Type: application/json
@@ -31,11 +31,12 @@ Content-Type: application/json
         "currency": "USD",
         "availability_note": "available",
         "available": "yes",
-        "countries": [{
-            "country": "US",
-            "vat_rate": 0,
-            "delivery_charge": 0
-        }
+        "countries": [
+            {
+                "country": "US",
+                "vat_rate": 0,
+                "delivery_charge": 0
+            }
         ],
         "international_requirements": 0,
         "minimum_age": 21,
@@ -45,7 +46,9 @@ Content-Type: application/json
         "lowest_denomination": null,
         "catalogue_id": 1,
         "brand_id": 1,
-        "variants": ["{\"available\": 1, \"product_sku\": \"000123454\", \"sku\": \"000123457\", \"face_value\": null, \"base_price\": 100.0, \"voucher_status\": 0, \"variant\":\"test\" }"]
+        "variants": [
+            "{ \"available\":1, \"product_sku\":\"000123454\", \"sku\":\"000123457\", \"face_value\":null, \"base_price\":100.0, \"voucher_status\":0, \"variant\":\"test\" }"
+        ]
     }
 }
 ```


### PR DESCRIPTION
Updating verbiage for product update and create API documentation, to further clarify how product variants should be defined.
Also addressed an issue with docker compose recipe and updated readme with instructions for testing locally.

---

Ref: REW-2794

<details>
<summary id='change-log'>Change Log</summary>

🔬 [Compare](https://github.com/corporaterewards/docs-redstone/compare/f0cb183f4c2174fc63a055c621263e9c04dc7f9f..15072eefd43716c44b15556e013f19e9e8c17626)

(689f0b55b756d57da389380604b8b202e39384ad) [2026-02-03T16:18:54+0000] fix: 🔧 address entrypoint and command issue
- The default entry point for this build was the slate script; consequently any shell commands passed into this script caused it to hang.
- By overriding the default entry point to bash, we can instead pass shell commands to perform all the desired steps.
- ref: REW-2794

(4758c13d608ebd1d05159adede2d4de45243ec1e) [2026-02-03T23:54:33+0000] docs: 📝 add important note about updating product variants in API documentation
- ref: REW-2794

(20d669f07fadaad8b2bae03078b9765cf999356e) [2026-02-03T23:55:24+0000] style: 🎨 improve formatting in update product v2 API documentation
- ref: REW-2794

(85f86aa902abaf34b5fad33001514541593f31cf) [2026-02-03T23:56:54+0000] docs: 📝 revise update product v2 API documentation to clarify variants structure
- Also moved brand ID definition above variants to keep all the variant details separate from the rest.
- ref: REW-2794

(ea85c4185167244948f744f1cb4744dd50d8bf46) [2026-02-03T23:57:49+0000] docs: 📝 revise create product v2 API documentation to clarify variants structure
- Also moved brand ID definition above variants to keep all the variant details separate from the rest.
- ref: REW-2794

(ea993914174ddfc7bbe1f2f1991d215f61410c4a) [2026-02-03T23:58:12+0000] docs: 📝 revise create product v3 API documentation to clarify variants structure
- ref: REW-2794

(69c79ffe7fda82de8d489d97289232d828d0b7ca) [2026-02-04T00:12:46+0000] style: 🎨 improve formatting in README.md for consistency
- ref: REW-2794

(15072eefd43716c44b15556e013f19e9e8c17626) [2026-02-04T00:12:56+0000] docs: 📝 add local testing requirements and steps to README.md
- ref: REW-2794

</details>